### PR TITLE
add in possibilities for icon_descriptor values

### DIFF
--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -55,6 +55,26 @@ interface ForecastRequest {
 }
 ```
 
+Values for icon_descriptor include, but are not limited to:
+- 'clear': Clear sky, typically indicating no clouds.
+- 'sunny': Bright and sunny conditions.
+- 'mostly_sunny': Predominantly sunny with some clouds.
+- 'partly_cloudy': A mix of sun and clouds.
+- 'cloudy': Overcast or cloudy skies.
+- 'rain': Rainy conditions.
+- 'shower': Intermittent or light rain showers.
+- 'light_rain': Light rainfall.
+- 'heavy_shower': Heavy rain showers.
+- 'storm': Stormy conditions, possibly with thunder.
+- 'cyclone': Cyclonic conditions or hurricanes.
+- 'windy': Strong winds.
+- 'hazy': Haze conditions, typically indicating reduced visibility.
+- 'fog': Foggy conditions, indicating very low visibility.
+- 'dusty': Dusty weather conditions.
+- 'frost': Frosty conditions, often with ice formation.
+- 'snow': Snowy conditions.
+
+
 ### Example output
 [Jump to finish](#3-hourly)
 

--- a/docs/forecasts.md
+++ b/docs/forecasts.md
@@ -28,10 +28,10 @@ interface ForecastItem {
   }
   now?: {
     is_night: boolean
-		now_label: string
-		later_label: string
-		temp_now: number
-		temp_later: number
+    now_label: string
+    later_label: string
+    temp_now: number
+    temp_later: number
   }
 
   date: string
@@ -55,24 +55,25 @@ interface ForecastRequest {
 }
 ```
 
-Values for icon_descriptor include, but are not limited to:
-- 'clear': Clear sky, typically indicating no clouds.
-- 'sunny': Bright and sunny conditions.
-- 'mostly_sunny': Predominantly sunny with some clouds.
-- 'partly_cloudy': A mix of sun and clouds.
-- 'cloudy': Overcast or cloudy skies.
-- 'rain': Rainy conditions.
-- 'shower': Intermittent or light rain showers.
-- 'light_rain': Light rainfall.
-- 'heavy_shower': Heavy rain showers.
-- 'storm': Stormy conditions, possibly with thunder.
-- 'cyclone': Cyclonic conditions or hurricanes.
-- 'windy': Strong winds.
-- 'hazy': Haze conditions, typically indicating reduced visibility.
-- 'fog': Foggy conditions, indicating very low visibility.
-- 'dusty': Dusty weather conditions.
-- 'frost': Frosty conditions, often with ice formation.
-- 'snow': Snowy conditions.
+The `icon_descriptor` field can have these values:
+
+`clear` (Clear sky, typically indicating no clouds),
+`sunny` (Bright and sunny conditions),
+`mostly_sunny` (Predominantly sunny with some clouds),
+`partly_cloudy` (A mix of sun and clouds),
+`cloudy` (Overcast or cloudy skies),
+`rain` (Rainy conditions),
+`shower` (Intermittent or light rain showers),
+`light_rain` (Light rainfall),
+`heavy_shower` (Heavy rain showers),
+`storm` (Stormy conditions, possibly with thunder),
+`cyclone` (Cyclonic conditions or hurricanes),
+`windy` (Strong winds),
+`hazy` (Haze conditions, typically indicating reduced visibility),
+`fog` (Foggy conditions, indicating very low visibility),
+`dusty` (Dusty weather conditions),
+`frost` (Frosty conditions, often with ice formation),
+`snow` (Snowy conditions).
 
 
 ### Example output


### PR DESCRIPTION
The icon_descriptor is a string value that succinctly summarises the overall weather condition expected for the given time period, such as 'sunny', 'cloudy', 'rain', etc.

The pull request adds in the possible values returned, which include:

'clear': Clear sky, typically indicating no clouds.
'sunny': Bright and sunny conditions.
'mostly_sunny': Predominantly sunny with some clouds.
'partly_cloudy': A mix of sun and clouds.
'cloudy': Overcast or cloudy skies.
'rain': Rainy conditions.
'shower': Intermittent or light rain showers.
'light_rain': Light rainfall.
'heavy_shower': Heavy rain showers.
'storm': Stormy conditions, possibly with thunder.
'cyclone': Cyclonic conditions or hurricanes.
'windy': Strong winds.
'hazy': Haze conditions, typically indicating reduced visibility.
'fog': Foggy conditions, indicating very low visibility.
'dusty': Dusty weather conditions.
'frost': Frosty conditions, often with ice formation.
'snow': Snowy conditions.
